### PR TITLE
Clears input value if no color is selected.

### DIFF
--- a/javascript/colorpicker.js
+++ b/javascript/colorpicker.js
@@ -6,7 +6,9 @@
 
 				if(self.attr('type') !== 'color') {
 					var options = $.extend(self.data('spectrum-options'), {change: function(c) {
-						if(c === null || c._a === 0) {
+						if( c === null ){
+							self.val('');
+						}else if( c._a === 0) {
 							self.val('transparent');
 						} else if(c._a === 1) {
 							self.val(c.toHexString());


### PR DESCRIPTION
The input value should be cleared if no color selected, instead of setting value to "transparent" as current.